### PR TITLE
126 merge mode for user code templates

### DIFF
--- a/plugins/com.google.eclipse.mechanic.tests/src/com/google/eclipse/mechanic/internal/EpfFileModelTest.java
+++ b/plugins/com.google.eclipse.mechanic.tests/src/com/google/eclipse/mechanic/internal/EpfFileModelTest.java
@@ -9,9 +9,9 @@
 
 package com.google.eclipse.mechanic.internal;
 
-import junit.framework.TestCase;
-
 import com.google.eclipse.mechanic.tests.internal.RunAsJUnitTest;
+
+import junit.framework.TestCase;
 
 /**
  * Tests for {@link EpfFileModel}.
@@ -20,33 +20,40 @@ import com.google.eclipse.mechanic.tests.internal.RunAsJUnitTest;
 public class EpfFileModelTest extends TestCase {
   public void testTitle() {
     try {
-      new EpfFileModel(null, "x", TaskType.LASTMOD);
+      new EpfFileModel(null, "x", TaskType.LASTMOD, XMLMode.OVERWRITE);
       fail("exception expected");
     } catch (NullPointerException e) {}
 
-    assertEquals("Y", new EpfFileModel("Y", "x", TaskType.LASTMOD).getTitle());
+    assertEquals("Y",
+        new EpfFileModel("Y", "x", TaskType.LASTMOD, XMLMode.OVERWRITE)
+            .getTitle());
   }
 
   public void testDescription() {
     try {
-      new EpfFileModel("x", null, TaskType.LASTMOD);
+      new EpfFileModel("x", null, TaskType.LASTMOD, XMLMode.OVERWRITE);
       fail("exception expected");
     } catch (NullPointerException e) {}
 
-    assertEquals("Y", new EpfFileModel("x", "Y", TaskType.LASTMOD).getDescription());
+    assertEquals("Y",
+        new EpfFileModel("x", "Y", TaskType.LASTMOD, XMLMode.OVERWRITE)
+            .getDescription());
   }
 
   public void testTaskType() {
     try {
-      new EpfFileModel("x", "y", null);
+      new EpfFileModel("x", "y", null, XMLMode.OVERWRITE);
       fail("exception expected");
     } catch (NullPointerException e) {}
 
-    assertEquals(TaskType.LASTMOD, new EpfFileModel("x", "Y", TaskType.LASTMOD).getTaskType());
+    assertEquals(TaskType.LASTMOD,
+        new EpfFileModel("x", "Y", TaskType.LASTMOD, XMLMode.OVERWRITE)
+            .getTaskType());
   }
 
   public void testElements() {
-    EpfFileModel model = new EpfFileModel("x", "y", TaskType.RECONCILE);
+    EpfFileModel model = new EpfFileModel("x", "y", TaskType.RECONCILE,
+        XMLMode.OVERWRITE);
     assertEquals(0, model.getPreferences().size());
 
     model.addElement("first", "second");

--- a/plugins/com.google.eclipse.mechanic.tests/src/com/google/eclipse/mechanic/internal/EpfFileModelWriterTest.java
+++ b/plugins/com.google.eclipse.mechanic.tests/src/com/google/eclipse/mechanic/internal/EpfFileModelWriterTest.java
@@ -12,24 +12,26 @@ package com.google.eclipse.mechanic.internal;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
-import junit.framework.TestCase;
-
 import com.google.common.base.Splitter;
 import com.google.common.collect.Iterables;
+
+import junit.framework.TestCase;
 
 /**
  * Tests for {@link EpfFileModelWriter}.
  */
 public class EpfFileModelWriterTest extends TestCase {
   public void testSimple() throws IOException {
-    EpfFileModel model = new EpfFileModel("TiTlE", "DeScRiPtIoN", TaskType.RECONCILE);
+    EpfFileModel model = new EpfFileModel("TiTlE", "DeScRiPtIoN",
+        TaskType.RECONCILE, XMLMode.OVERWRITE);
     model.addElement("first", "second");
     String actual = writeToString(model);
     assertBasics(actual);
   }
 
   public void testOnePreference() throws IOException {
-    EpfFileModel model = new EpfFileModel("TiTlE", "DeScRiPtIoN", TaskType.RECONCILE);
+    EpfFileModel model = new EpfFileModel("TiTlE", "DeScRiPtIoN",
+        TaskType.RECONCILE, XMLMode.OVERWRITE);
     model.addElement("first", "second");
     String actual = writeToString(model);
     assertBasics(actual);
@@ -37,7 +39,8 @@ public class EpfFileModelWriterTest extends TestCase {
   }
 
   public void testTwoPreferences() throws IOException {
-    EpfFileModel model = new EpfFileModel("TiTlE", "DeScRiPtIoN", TaskType.RECONCILE);
+    EpfFileModel model = new EpfFileModel("TiTlE", "DeScRiPtIoN",
+        TaskType.RECONCILE, XMLMode.OVERWRITE);
     model.addElement("first", "second");
     model.addElement("third", "fourth");
     String actual = writeToString(model);
@@ -47,7 +50,8 @@ public class EpfFileModelWriterTest extends TestCase {
   }
 
   public void testNewlineInPreferences() throws IOException {
-    EpfFileModel model = new EpfFileModel("TiTlE", "DeScRiPtIoN", TaskType.RECONCILE);
+    EpfFileModel model = new EpfFileModel("TiTlE", "DeScRiPtIoN",
+        TaskType.RECONCILE, XMLMode.OVERWRITE);
     model.addElement("key", "longline\nnewline");
     String actual = writeToString(model);
     fail("didn't test this one yet " + actual);

--- a/plugins/com.google.eclipse.mechanic/src/com/google/eclipse/mechanic/ReconcilingPreferencesTask.java
+++ b/plugins/com.google.eclipse.mechanic/src/com/google/eclipse/mechanic/ReconcilingPreferencesTask.java
@@ -15,6 +15,8 @@ import java.util.Properties;
 
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 
+import com.google.eclipse.mechanic.internal.XMLMode;
+
 /**
  * Models an Eclipse preferences export file as a series of individual
  * preference reconcilers. If any of the reconcilers need fixing, they
@@ -25,16 +27,19 @@ import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 public abstract class ReconcilingPreferencesTask extends PreferenceReconcilerTask {
 
   private final IResourceTaskReference taskRef;
+  private XMLMode xmlMode;
 
-  public ReconcilingPreferencesTask(
-      IResourceTaskReference taskRef, IEclipsePreferences prefsRoot) throws IOException {
+  public ReconcilingPreferencesTask(IResourceTaskReference taskRef,
+      IEclipsePreferences prefsRoot) throws IOException {
     super(prefsRoot);
     this.taskRef = taskRef;
     initReconcilers();
   }
 
-  public ReconcilingPreferencesTask(IResourceTaskReference taskRef) throws IOException {
+  public ReconcilingPreferencesTask(IResourceTaskReference taskRef,
+      XMLMode xmlMode) throws IOException {
     this.taskRef = taskRef;
+    this.xmlMode = xmlMode;
     initReconcilers();
   }
 
@@ -60,7 +65,7 @@ public abstract class ReconcilingPreferencesTask extends PreferenceReconcilerTas
       // Ignore entries like "file_export_version=3.0"
       if (!id.isEmpty() && id.charAt(0) == '/') {
         String value = (String) entry.getValue();
-        addReconciler(createReconciler(id, value));
+        addReconciler(createReconciler(id, value, xmlMode));
       }
     }
   }

--- a/plugins/com.google.eclipse.mechanic/src/com/google/eclipse/mechanic/internal/CustomTemplateMerger.java
+++ b/plugins/com.google.eclipse.mechanic/src/com/google/eclipse/mechanic/internal/CustomTemplateMerger.java
@@ -1,0 +1,217 @@
+package com.google.eclipse.mechanic.internal;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.TransformerFactoryConfigurationError;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+
+import org.osgi.service.prefs.BackingStoreException;
+import org.osgi.service.prefs.Preferences;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+
+import com.google.eclipse.mechanic.plugin.core.MechanicLog;
+
+public class CustomTemplateMerger {
+
+  private static final MechanicLog log = MechanicLog.getDefault();
+
+  public static final String INSTANCE_ORG_ECLIPSE_JDT_UI = "/instance/org.eclipse.jdt.ui";
+  public static final String CUSTOM_TEMPLATES_PREFERENCE_KEY = "org.eclipse.jdt.ui.text.custom_templates";
+  private Document oldXml;
+  private Document newXml;
+  private Preferences mergingNode;
+  private String newXmlString;
+
+  private class CustomTemplate {
+
+    private Node node;
+    private String name;
+    private String context;
+    private String autoinsert;
+    private String deleted;
+    private String enabled;
+    private String description;
+    private String value;
+    private boolean deepEquals;
+
+    public CustomTemplate(Node node, boolean deepEquals) {
+      this.node = node;
+      this.deepEquals = deepEquals;
+      name = node.getAttributes().getNamedItem("name").getNodeValue();
+      context = node.getAttributes().getNamedItem("context").getNodeValue();
+      autoinsert = node.getAttributes().getNamedItem("autoinsert")
+          .getNodeValue();
+      deleted = node.getAttributes().getNamedItem("deleted").getNodeValue();
+      enabled = node.getAttributes().getNamedItem("enabled").getNodeValue();
+      description = node.getAttributes().getNamedItem("description")
+          .getNodeValue();
+      value = node.getTextContent();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (obj instanceof CustomTemplate) {
+        return ((CustomTemplate) obj).name.equals(name)
+            && ((CustomTemplate) obj).context.equals(context)
+            && (!deepEquals
+                || ((CustomTemplate) obj).autoinsert.equals(autoinsert)
+                    && ((CustomTemplate) obj).deleted.equals(deleted)
+                    && ((CustomTemplate) obj).description.equals(description)
+                    && ((CustomTemplate) obj).enabled.equals(enabled)
+                    && ((CustomTemplate) obj).value.equals(value));
+      }
+      return super.equals(obj);
+    }
+
+    @Override
+    public int hashCode() {
+      if (deepEquals) {
+        return name.hashCode() + context.hashCode() + autoinsert.hashCode()
+            + deleted.hashCode() + enabled.hashCode() + description.hashCode()
+            + value.hashCode();
+      }
+      return name.hashCode() + context.hashCode();
+    }
+
+  }
+
+  public CustomTemplateMerger(Preferences newPrefs, Preferences oldPrefs) {
+    try {
+      if (newPrefs.nodeExists(INSTANCE_ORG_ECLIPSE_JDT_UI)) {
+        mergingNode = newPrefs.node(INSTANCE_ORG_ECLIPSE_JDT_UI);
+        String newPref = mergingNode.get(CUSTOM_TEMPLATES_PREFERENCE_KEY, null);
+        if (oldPrefs.nodeExists(INSTANCE_ORG_ECLIPSE_JDT_UI)) {
+          Preferences oldNode = oldPrefs.node(INSTANCE_ORG_ECLIPSE_JDT_UI);
+          String oldPref = oldNode.get(CUSTOM_TEMPLATES_PREFERENCE_KEY, null);
+          DocumentBuilder newXmlDocumentBuilder = DocumentBuilderFactory
+              .newInstance().newDocumentBuilder();
+          DocumentBuilder oldXmlDocumentBuilder = DocumentBuilderFactory
+              .newInstance().newDocumentBuilder();
+
+          newXml = newXmlDocumentBuilder
+              .parse(new InputSource(new StringReader(newPref)));
+
+          oldXml = oldXmlDocumentBuilder
+              .parse(new InputSource(new StringReader(oldPref)));
+
+        }
+      }
+    } catch (BackingStoreException e) {
+      log.logError(e);
+    } catch (SAXException e) {
+      log.logError(e);
+    } catch (IOException e) {
+      log.logError(e);
+    } catch (ParserConfigurationException e) {
+      log.logError(e);
+    }
+  }
+
+  public CustomTemplateMerger(String newPref, String oldPref) {
+    try {
+      DocumentBuilder newXmlDocumentBuilder = DocumentBuilderFactory
+          .newInstance().newDocumentBuilder();
+      DocumentBuilder oldXmlDocumentBuilder = DocumentBuilderFactory
+          .newInstance().newDocumentBuilder();
+
+      newXml = newXmlDocumentBuilder
+          .parse(new InputSource(new StringReader(newPref)));
+
+      oldXml = oldXmlDocumentBuilder
+          .parse(new InputSource(new StringReader(oldPref)));
+    } catch (SAXException e) {
+      log.logError(e);
+    } catch (IOException e) {
+      log.logError(e);
+    } catch (ParserConfigurationException e) {
+      log.logError(e);
+    }
+  }
+
+  /**
+   * merges the old custom templates (oldPrefs) to the new custom templates
+   * (newPrefs), if an template is on both (according to
+   * {@link CustomTemplate#equals(Object)})then the one in newPrefs will be
+   * applied
+   * 
+   * @param newPrefs
+   * @param oldPrefs
+   */
+  public String mergeCustomTemplates() {
+    mergeOrCheckCustomTemplates(true);
+    if (mergingNode != null) {
+      mergingNode.put(CUSTOM_TEMPLATES_PREFERENCE_KEY, newXmlString);
+    }
+    return newXmlString;
+  }
+
+  private boolean mergeOrCheckCustomTemplates(boolean merge)
+      throws TransformerFactoryConfigurationError {
+    try {
+      Set<CustomTemplate> newCustomTemplates = extractTemplates(newXml, !merge);
+      Set<CustomTemplate> oldCustomTemplates = extractTemplates(oldXml, !merge);
+
+      NodeList elementsByTagName = newXml.getElementsByTagName("templates");
+      Node templatesNode = elementsByTagName.item(0);
+      Iterator<CustomTemplate> iterator = oldCustomTemplates.iterator();
+      boolean atLeastOneMergeWasMade = false;
+      while (iterator.hasNext()) {
+        CustomTemplate next = iterator.next();
+        if (!newCustomTemplates.contains(next)) {
+          if (merge) {
+            templatesNode.appendChild(newXml.importNode(next.node, true));
+          }
+          atLeastOneMergeWasMade = true;
+        }
+      }
+      if (!merge) {
+        return atLeastOneMergeWasMade;
+      }
+      TransformerFactory factory = TransformerFactory.newInstance();
+      factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+      Transformer transformer = factory.newTransformer();
+      transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+      StringWriter writer = new StringWriter();
+
+      transformer.transform(new DOMSource(newXml), new StreamResult(writer));
+      newXmlString = writer.getBuffer().toString();
+    } catch (TransformerException e) {
+      log.logError(e);
+    }
+    return true;
+  }
+
+  public boolean isSomethingToMerge() {
+    return mergeOrCheckCustomTemplates(false);
+  }
+
+  private Set<CustomTemplate> extractTemplates(Document newXml,
+      boolean deepEquals) {
+    NodeList newTemplateNodes = newXml.getElementsByTagName("template");
+    Set<CustomTemplate> newCustomTemplates = new HashSet<CustomTemplate>();
+    for (int i = 0; i < newTemplateNodes.getLength(); i++) {
+      Node item = newTemplateNodes.item(i);
+      newCustomTemplates
+          .add(new CustomTemplate(item.cloneNode(true), deepEquals));
+    }
+    return newCustomTemplates;
+  }
+}

--- a/plugins/com.google.eclipse.mechanic/src/com/google/eclipse/mechanic/internal/EpfFileModel.java
+++ b/plugins/com.google.eclipse.mechanic/src/com/google/eclipse/mechanic/internal/EpfFileModel.java
@@ -24,6 +24,7 @@ public class EpfFileModel {
   private final String title;
   private final String description;
   private final TaskType taskType;
+  private final XMLMode xmlMode;
   private final Map<String, String> preferences = new HashMap<String, String>();
   
   /**
@@ -32,14 +33,17 @@ public class EpfFileModel {
    * @param description the description of this task. Listed in the 
    *     @description field.
    * @param taskType the type of task to create.
+   *  @param xmlMode the xml mode to use
    */
   public EpfFileModel(
       String title, 
       String description, 
-      TaskType taskType) {
+      TaskType taskType, 
+      XMLMode xmlMode) {
     this.title = Preconditions.checkNotNull(title);
     this.description = Preconditions.checkNotNull(description);
     this.taskType = Preconditions.checkNotNull(taskType);
+    this.xmlMode = Preconditions.checkNotNull(xmlMode);
   }
   
   /**
@@ -65,6 +69,10 @@ public class EpfFileModel {
 
   public TaskType getTaskType() {
     return taskType;
+  }
+
+  public XMLMode getXmlMode() {
+    return xmlMode;
   }
 
   public Map<String, String> getPreferences() {

--- a/plugins/com.google.eclipse.mechanic/src/com/google/eclipse/mechanic/internal/EpfFileModelWriter.java
+++ b/plugins/com.google.eclipse.mechanic/src/com/google/eclipse/mechanic/internal/EpfFileModelWriter.java
@@ -33,9 +33,10 @@ public class EpfFileModelWriter {
 
   public static void write(EpfFileModel model, OutputStream outputStream) throws IOException {
     PrintWriter commentPrintWriter = new PrintWriter(outputStream);
-    commentPrintWriter.format("# @title %s\n", model.getTitle());
-    commentPrintWriter.format("# @description %s\n", model.getDescription());
-    commentPrintWriter.format("# @task_type %s\n#\n", model.getTaskType().toString());
+    commentPrintWriter.format("# @title %s%n", model.getTitle());
+    commentPrintWriter.format("# @description %s%n", model.getDescription());
+    commentPrintWriter.format("# @task_type %s%n", model.getTaskType().toString());
+    commentPrintWriter.format("# @xml_mode %s%n#%n", model.getXmlMode().toString());
     commentPrintWriter.println(
         "# Created by the Workspace Mechanic Preference Recorder");
     commentPrintWriter.flush();

--- a/plugins/com.google.eclipse.mechanic/src/com/google/eclipse/mechanic/internal/PreferenceFileTaskScanner.java
+++ b/plugins/com.google.eclipse.mechanic/src/com/google/eclipse/mechanic/internal/PreferenceFileTaskScanner.java
@@ -15,12 +15,12 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.logging.Logger;
 
-import com.google.eclipse.mechanic.ListCollector;
-import com.google.eclipse.mechanic.ResourceTaskScanner;
 import com.google.eclipse.mechanic.IResourceTaskProvider;
 import com.google.eclipse.mechanic.IResourceTaskReference;
 import com.google.eclipse.mechanic.LastModifiedPreferencesFileTask;
+import com.google.eclipse.mechanic.ListCollector;
 import com.google.eclipse.mechanic.ReconcilingPreferencesTask;
+import com.google.eclipse.mechanic.ResourceTaskScanner;
 import com.google.eclipse.mechanic.Task;
 import com.google.eclipse.mechanic.TaskCollector;
 import com.google.eclipse.mechanic.plugin.core.MechanicLog;
@@ -109,7 +109,7 @@ public final class PreferenceFileTaskScanner extends ResourceTaskScanner {
     private final Header header;
 
     public ReconcilingEpfTask(IResourceTaskReference taskRef, Header header) throws IOException {
-      super(taskRef);
+      super(taskRef, header.getXmlMode());
       this.header = header;
     }
 
@@ -133,7 +133,7 @@ public final class PreferenceFileTaskScanner extends ResourceTaskScanner {
 
     public LastmodEpfTask(IResourceTaskReference taskRef, Header header) {
       super(taskRef, MechanicPlugin.getDefault().getMechanicPreferences(),
-          MechanicLog.getDefault());
+          MechanicLog.getDefault(), header.getXmlMode());
       this.header = header;
     }
 
@@ -156,6 +156,7 @@ public final class PreferenceFileTaskScanner extends ResourceTaskScanner {
     private static final String TITLE_TAG = "@title";
     private static final String DESCRIPTION_TAG = "@description";
     private static final String TYPE_TAG = "@task_type";
+    private static final String XML_MODE_TAG = "@xml_mode";
 
     // Please don't use this tag in your EPF tasks.
     // Consider it deprecated, but don't remove it; it's kept for backwards compatibility.
@@ -163,6 +164,7 @@ public final class PreferenceFileTaskScanner extends ResourceTaskScanner {
 
     private final IResourceTaskReference taskRef;
     private TaskType type;
+    private XMLMode xmlMode;
     private String title;
     private String description;
 
@@ -171,6 +173,7 @@ public final class PreferenceFileTaskScanner extends ResourceTaskScanner {
 
       // give the file friendly default values
       type = TaskType.LASTMOD;
+      xmlMode = XMLMode.OVERWRITE;
       title = "Import preferences from: " + taskRef.getName();
       description = "Imports the preferences from: " + taskRef.getPath();
     }
@@ -259,10 +262,20 @@ public final class PreferenceFileTaskScanner extends ResourceTaskScanner {
       if (i == 0) {
         type = TaskType.valueOf(line.substring(TYPE_TAG.length()).trim());
       }
+
+      // Checking for new @xml_mode tag.
+      i = line.indexOf(XML_MODE_TAG);
+      if (i == 0) {
+        xmlMode = XMLMode.valueOf(line.substring(XML_MODE_TAG.length()).trim());
+      }
     }
 
     public TaskType getType() {
       return type;
+    }
+
+    public XMLMode getXmlMode() {
+      return xmlMode;
     }
 
     public String getDescription() {
@@ -280,6 +293,7 @@ public final class PreferenceFileTaskScanner extends ResourceTaskScanner {
   interface Header {
 
     public TaskType getType();
+    public XMLMode getXmlMode();
     public String getDescription();
     public String getTitle();
 

--- a/plugins/com.google.eclipse.mechanic/src/com/google/eclipse/mechanic/internal/XMLMode.java
+++ b/plugins/com.google.eclipse.mechanic/src/com/google/eclipse/mechanic/internal/XMLMode.java
@@ -1,0 +1,19 @@
+package com.google.eclipse.mechanic.internal;
+
+/**
+ * An enum that defines how XML files should be handled.
+ */
+public enum XMLMode {
+
+  /**
+   * the current xml will be overwritten by the one from preference file
+   */
+  OVERWRITE,
+
+  /**
+   * the current xml should be merged with the one from preference file new
+   * entries will be added, not existing will stay, existing will be handled
+   * according to the {@link TaskType}
+   */
+  MERGE;
+}

--- a/plugins/com.google.eclipse.mechanic/src/com/google/eclipse/mechanic/plugin/ui/BaseOutputDialog.java
+++ b/plugins/com.google.eclipse.mechanic/src/com/google/eclipse/mechanic/plugin/ui/BaseOutputDialog.java
@@ -40,6 +40,7 @@ import org.eclipse.swt.widgets.Text;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.eclipse.mechanic.internal.TaskType;
+import com.google.eclipse.mechanic.internal.XMLMode;
 import com.google.eclipse.mechanic.plugin.core.MechanicPlugin;
 
 /**
@@ -50,7 +51,8 @@ public abstract class BaseOutputDialog extends Dialog {
   enum Component {
     TITLE,
     DESCRIPTION,
-    TASK_TYPE
+    TASK_TYPE, 
+    XML_MODE
   }
 
   private final String extension;
@@ -60,6 +62,7 @@ public abstract class BaseOutputDialog extends Dialog {
   private Text titleText;
   private Text descriptionText;
   private Combo taskTypeCombo;
+  private Combo xmlModeCombo;
   private Text savedLocationText;
 
   /**
@@ -115,7 +118,9 @@ public abstract class BaseOutputDialog extends Dialog {
     }
     IDialogSettings settings = MechanicPlugin.getDefault().getDialogSettings();
     IDialogSettings section = settings.getSection(dialogSettingsSection);
-    if (section == null) section = settings.addNewSection(dialogSettingsSection);
+    if (section == null) {
+      section = settings.addNewSection(dialogSettingsSection);
+    }
     return section;
   }
 
@@ -187,6 +192,19 @@ public abstract class BaseOutputDialog extends Dialog {
       taskTypeCombo.setLayoutData(new GridData(SWT.BEGINNING, SWT.CENTER, true, false, 2, 1));
       taskTypeCombo.addModifyListener(validateOnChange);
       taskTypeCombo.setEnabled(components.contains(Component.TASK_TYPE));
+    }
+
+    if (components.contains(Component.XML_MODE)) {
+      createLabel(container, "XML-Mode:");
+      xmlModeCombo = new Combo(container, SWT.DROP_DOWN | SWT.READ_ONLY);
+      // Ensuring the order hasn't changed, as we rely on that.
+      Preconditions.checkState(TaskType.values()[0] == TaskType.LASTMOD);
+      xmlModeCombo.setItems(new String[] { "Overwrite", "Merge" });
+      xmlModeCombo.select(0);
+      xmlModeCombo.setLayoutData(
+          new GridData(SWT.BEGINNING, SWT.CENTER, true, false, 2, 1));
+      xmlModeCombo.addModifyListener(validateOnChange);
+      xmlModeCombo.setEnabled(components.contains(Component.XML_MODE));
     }
 
     // Add saved file location
@@ -358,6 +376,18 @@ public abstract class BaseOutputDialog extends Dialog {
 
   public void setTaskType(TaskType taskType) {
     taskTypeCombo.select(Arrays.asList(TaskType.values()).indexOf(taskType));
+  }
+
+  /**
+   * Get xml mode provided by the user. Only valid after the dialog has been
+   * created.
+   */
+  public XMLMode getXmlMode() {
+    return XMLMode.values()[xmlModeCombo.getSelectionIndex()];
+  }
+
+  public void setXmlMode(XMLMode xmlMode) {
+    xmlModeCombo.select(Arrays.asList(XMLMode.values()).indexOf(xmlMode));
   }
 
   public String getLocation() {

--- a/plugins/com.google.eclipse.mechanic/src/com/google/eclipse/mechanic/plugin/ui/EpfOutputDialog.java
+++ b/plugins/com.google.eclipse.mechanic/src/com/google/eclipse/mechanic/plugin/ui/EpfOutputDialog.java
@@ -211,7 +211,7 @@ public class EpfOutputDialog extends BaseOutputDialog {
     }
     
     // Save the preferences into an EPF file
-    EpfFileModel epfFile = new EpfFileModel(getTitle(), getDescription(), getTaskType());
+    EpfFileModel epfFile = new EpfFileModel(getTitle(), getDescription(), getTaskType(), getXmlMode());
     
     Map<String, String> savedPreferences = getSavedPreferences();
     


### PR DESCRIPTION
Created a new property for the file called XMLMode. Contains 2 different modes OVERWRITE (default) which acts like before and MERGE, which is trying to merge the XML files.
Feature is only applied to the custom code templates, assuming a template is defined by name and context.
Enhanced the UI of the preferences recorder to able to choose the option.